### PR TITLE
Prevent crash when using DX12 with Debug

### DIFF
--- a/src/GraphicsAPI/GraphicsAPI.cpp
+++ b/src/GraphicsAPI/GraphicsAPI.cpp
@@ -477,13 +477,17 @@ namespace KickstartRT_NativeLayer::GraphicsAPI {
             return false;
         }
 
+        auto flags = heapEntry.m_descHeap->GetDesc().Flags;
+
         retAllocationInfo->m_numDescriptors = nbEntryToAllocate;
         retAllocationInfo->m_incrementSize = heapEntry.m_incrementSize;
         retAllocationInfo->m_hCPU = heapEntry.m_descHeap->GetCPUDescriptorHandleForHeapStart();
-        retAllocationInfo->m_hGPU = heapEntry.m_descHeap->GetGPUDescriptorHandleForHeapStart();
+        if (flags & D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE)
+            retAllocationInfo->m_hGPU = heapEntry.m_descHeap->GetGPUDescriptorHandleForHeapStart();
 
         retAllocationInfo->m_hCPU.ptr += heapEntry.m_incrementSize * heapEntry.m_currentOffset;
-        retAllocationInfo->m_hGPU.ptr += heapEntry.m_incrementSize * heapEntry.m_currentOffset;
+        if (flags & D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE)
+            retAllocationInfo->m_hGPU.ptr += heapEntry.m_incrementSize * heapEntry.m_currentOffset;
 
         heapEntry.m_currentOffset += nbEntryToAllocate;
 


### PR DESCRIPTION
On Win11, with Windows 11 SDK 10.0.22000.0, while running KickstartRT_demo:
Calling _GetGPUDescriptorHandleForHeapStart_ when _D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE_ is not defined as flag causes 
`
D3D12 ERROR: ID3D12DescriptorHeap::GetGPUDescriptorHandleForHeapStart: GetGPUDescriptorHandleForHeapStart is invalid to call on a descriptor heap that does not have DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE set. If the heap is not supposed to be shader visible, then GetCPUDescriptorHandleForHeapStart would be the appropriate method to call. That call is valid both for shader visible and non shader visible descriptor heaps. [ STATE_GETTING ERROR #1315: DESCRIPTOR_HEAP_NOT_SHADER_VISIBLE]
`
Exception doesn't happen when rebuilt with Release, or when using Vulkan